### PR TITLE
Add textual TUI scaffold

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+"""Entry point for Nitra-TUI application."""
+
+from nitra.app import NitraApp
+
+
+if __name__ == "__main__":
+    app = NitraApp()
+    app.run()

--- a/nitra/__init__.py
+++ b/nitra/__init__.py
@@ -1,0 +1,4 @@
+"""Nitra-TUI package initialization."""
+
+__all__ = ["app", "bot_manager", "panels", "layout"]
+__version__ = "0.1.0"

--- a/nitra/app.py
+++ b/nitra/app.py
@@ -1,0 +1,23 @@
+"""Main application entry for Nitra-TUI."""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+
+from .bot_manager import manager
+from .layout import NitraLayout
+
+
+class NitraApp(App):
+    """Textual application that mounts the main layout."""
+
+    TITLE = "Nitra-TUI"
+    CSS_PATH = "styles/base.tcss"
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:
+        yield NitraLayout()
+
+    async def on_mount(self) -> None:
+        """Start background updates."""
+        self.set_interval(5.0, manager.tick)

--- a/nitra/bot_manager.py
+++ b/nitra/bot_manager.py
@@ -1,0 +1,72 @@
+"""Simple singleton-style bot manager with mock data updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from random import choice, gauss, randint
+from typing import ClassVar, List
+
+
+@dataclass
+class Metrics:
+    """Represents mock bot metrics."""
+
+    pnl: float = 0.0
+    trades: int = 0
+    uptime: int = 0  # seconds
+
+
+@dataclass
+class BotManager:
+    """Central manager holding bot state and generating mock data."""
+
+    _instance: ClassVar["BotManager" | None] = None
+
+    metrics: Metrics = field(default_factory=Metrics)
+    logs: List[str] = field(default_factory=list)
+    signals: List[str] = field(default_factory=list)
+    commands: List[str] = field(default_factory=list)
+
+    def __new__(cls) -> "BotManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    # Update methods -----------------------------------------------------
+
+    def tick(self) -> None:
+        """Advance mock data for metrics, logs, and signals."""
+        self.update_metrics()
+        self.generate_signal()
+        self.generate_log()
+
+    def update_metrics(self) -> None:
+        """Simulate changing metrics."""
+        self.metrics.pnl += gauss(0, 1)
+        self.metrics.trades += randint(0, 2)
+        self.metrics.uptime += 5
+
+    def generate_signal(self) -> None:
+        """Append a random signal."""
+        signal = choice(["BUY", "SELL", "HOLD"])
+        self.signals.append(signal)
+        if len(self.signals) > 50:
+            self.signals.pop(0)
+
+    def generate_log(self) -> None:
+        """Append a random log entry."""
+        entry = f"Log entry {len(self.logs) + 1}"
+        self.logs.append(entry)
+        if len(self.logs) > 100:
+            self.logs.pop(0)
+
+    def add_command(self, command: str) -> None:
+        """Record a user command."""
+        self.commands.append(command)
+        if len(self.commands) > 50:
+            self.commands.pop(0)
+        self.logs.append(f"Command executed: {command}")
+
+
+# Convenience accessor -----------------------------------------------------
+manager = BotManager()

--- a/nitra/layout.py
+++ b/nitra/layout.py
@@ -1,0 +1,19 @@
+"""Application layout container."""
+
+from textual.containers import Grid
+from textual.app import ComposeResult
+
+from .panels.metrics_panel import MetricsPanel
+from .panels.signals_panel import SignalsPanel
+from .panels.command_panel import CommandPanel
+from .panels.logs_panel import LogsPanel
+
+
+class NitraLayout(Grid):
+    """Defines the 2x2 grid layout for the application."""
+
+    def compose(self) -> ComposeResult:
+        yield CommandPanel(id="command", classes="panel command")
+        yield MetricsPanel(id="metrics", classes="panel metrics")
+        yield LogsPanel(id="logs", classes="panel logs")
+        yield SignalsPanel(id="signals", classes="panel signals")

--- a/nitra/panels/__init__.py
+++ b/nitra/panels/__init__.py
@@ -1,0 +1,13 @@
+"""UI panels for Nitra-TUI."""
+
+from .command_panel import CommandPanel
+from .metrics_panel import MetricsPanel
+from .signals_panel import SignalsPanel
+from .logs_panel import LogsPanel
+
+__all__ = [
+    "CommandPanel",
+    "MetricsPanel",
+    "SignalsPanel",
+    "LogsPanel",
+]

--- a/nitra/panels/command_panel.py
+++ b/nitra/panels/command_panel.py
@@ -1,0 +1,35 @@
+"""User command input panel."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Input, TextLog
+from textual.widget import Widget
+
+from ..bot_manager import manager
+
+
+class CommandPanel(Widget):
+    """Panel for entering commands and viewing command history."""
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield TextLog(id="command_log", highlight=False)
+            yield Input(placeholder="Enter command...", id="command_input")
+
+    async def on_mount(self) -> None:
+        """Populate initial command history."""
+        log = self.query_one("#command_log", TextLog)
+        for cmd in manager.commands:
+            log.write_line(cmd)
+        log.auto_scroll_bottom = True
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle user command submission."""
+        command = event.value.strip()
+        if command:
+            manager.add_command(command)
+            log = self.query_one("#command_log", TextLog)
+            log.write_line(command)
+        event.input.value = ""

--- a/nitra/panels/logs_panel.py
+++ b/nitra/panels/logs_panel.py
@@ -1,0 +1,32 @@
+"""Panel showing debug logs."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import TextLog
+
+from ..bot_manager import manager
+
+
+class LogsPanel(Widget):
+    """Scrollable panel that displays log entries."""
+
+    _last_len: int = 0
+
+    def compose(self) -> ComposeResult:
+        yield TextLog(id="logs_log", highlight=False)
+
+    async def on_mount(self) -> None:
+        log = self.query_one("#logs_log", TextLog)
+        for entry in manager.logs:
+            log.write_line(entry)
+        self._last_len = len(manager.logs)
+        log.auto_scroll_bottom = True
+        self.set_interval(5.0, self.refresh_logs)
+
+    def refresh_logs(self) -> None:
+        log = self.query_one("#logs_log", TextLog)
+        for entry in manager.logs[self._last_len :]:
+            log.write_line(entry)
+        self._last_len = len(manager.logs)

--- a/nitra/panels/metrics_panel.py
+++ b/nitra/panels/metrics_panel.py
@@ -1,0 +1,29 @@
+"""Panel showing mock bot metrics."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ..bot_manager import manager
+
+
+class MetricsPanel(Widget):
+    """Display metrics that update periodically."""
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="metrics_text")
+
+    async def on_mount(self) -> None:
+        self.refresh_metrics()
+        self.set_interval(5.0, self.refresh_metrics)
+
+    def refresh_metrics(self) -> None:
+        metrics = manager.metrics
+        text = (
+            f"PnL: {metrics.pnl:.2f}\n"
+            f"Trades: {metrics.trades}\n"
+            f"Uptime: {metrics.uptime}s"
+        )
+        self.query_one("#metrics_text", Static).update(text)

--- a/nitra/panels/signals_panel.py
+++ b/nitra/panels/signals_panel.py
@@ -1,0 +1,32 @@
+"""Panel displaying mock trading signals."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import TextLog
+
+from ..bot_manager import manager
+
+
+class SignalsPanel(Widget):
+    """Show incoming BUY/SELL/HOLD signals."""
+
+    _last_len: int = 0
+
+    def compose(self) -> ComposeResult:
+        yield TextLog(id="signals_log", highlight=False)
+
+    async def on_mount(self) -> None:
+        log = self.query_one("#signals_log", TextLog)
+        for s in manager.signals:
+            log.write_line(s)
+        self._last_len = len(manager.signals)
+        log.auto_scroll_bottom = True
+        self.set_interval(5.0, self.refresh_signals)
+
+    def refresh_signals(self) -> None:
+        log = self.query_one("#signals_log", TextLog)
+        for s in manager.signals[self._last_len :]:
+            log.write_line(s)
+        self._last_len = len(manager.signals)

--- a/nitra/styles/base.tcss
+++ b/nitra/styles/base.tcss
@@ -1,0 +1,29 @@
+/* Base styles for Nitra-TUI panels */
+
+NitraLayout {
+    layout: grid;
+    grid-size: 2 2;
+    grid-gutter: 1;
+}
+
+
+.panel {
+    border: round $primary;
+    padding: 1 2;
+}
+
+.metrics {
+    background: $boost;
+}
+
+.signals {
+    background: $success;
+}
+
+.command {
+    background: $warning;
+}
+
+.logs {
+    background: $surface;
+}


### PR DESCRIPTION
## Summary
- add project entrypoint and app with 2x2 grid layout
- implement bot manager for mock data
- create panels for metrics, signals, commands and logs
- add basic styles
- refine grid layout and styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f9fc5b4a08330824b0a670de37cc3