### PR TITLE
Add minimal Textual layout

### DIFF
--- a/nitra_tui/layout.py
+++ b/nitra_tui/layout.py
@@ -1,0 +1,23 @@
+from textual.app import ComposeResult
+from textual.containers import Grid
+
+from .panels.deployments_panel import DeploymentsPanel
+from .panels.logs_panel import LogsPanel
+from .panels.portfolio_panel import PortfolioPanel
+from .panels.strategy_detail_panel import StrategyDetailPanel
+
+
+class NitraLayout(Grid):
+    """Grid layout with four panels."""
+
+    def compose(self) -> ComposeResult:
+        grid = Grid()
+        grid.set_columns("1fr 1fr")
+        grid.set_rows("1fr 1fr")
+        grid.place(
+            deployments=DeploymentsPanel(id="deployments"),
+            logs=LogsPanel(id="logs"),
+            portfolio=PortfolioPanel(id="portfolio"),
+            intel=StrategyDetailPanel(id="intel"),
+        )
+        yield grid

--- a/nitra_tui/main.py
+++ b/nitra_tui/main.py
@@ -1,0 +1,15 @@
+from textual.app import App, ComposeResult
+
+from .layout import NitraLayout
+
+
+class NitraApp(App):
+    """Main application class."""
+
+    def compose(self) -> ComposeResult:
+        yield NitraLayout()
+
+
+if __name__ == "__main__":
+    app = NitraApp()
+    app.run()

--- a/nitra_tui/panels/deployments_panel.py
+++ b/nitra_tui/panels/deployments_panel.py
@@ -1,0 +1,13 @@
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class DeploymentsPanel(Widget):
+    """Placeholder deployments panel."""
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+
+    def compose(self) -> ComposeResult:
+        yield Static("Deployments")

--- a/nitra_tui/panels/logs_panel.py
+++ b/nitra_tui/panels/logs_panel.py
@@ -1,0 +1,13 @@
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class LogsPanel(Widget):
+    """Placeholder logs panel."""
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+
+    def compose(self) -> ComposeResult:
+        yield Static("Logs")

--- a/nitra_tui/panels/portfolio_panel.py
+++ b/nitra_tui/panels/portfolio_panel.py
@@ -1,0 +1,13 @@
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class PortfolioPanel(Widget):
+    """Placeholder portfolio panel."""
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+
+    def compose(self) -> ComposeResult:
+        yield Static("Portfolio")

--- a/nitra_tui/panels/strategy_detail_panel.py
+++ b/nitra_tui/panels/strategy_detail_panel.py
@@ -1,0 +1,13 @@
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class StrategyDetailPanel(Widget):
+    """Placeholder strategy detail panel."""
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+
+    def compose(self) -> ComposeResult:
+        yield Static("Strategy Detail")


### PR DESCRIPTION
## Summary
- initialize the `nitra_tui` module
- implement `NitraApp` to boot the app
- build a 2x2 grid layout
- provide four placeholder panel widgets

## Testing
- `python - <<'PY'
import nitra_tui.main
print('Nitra main imported')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6870b3f3005883308a937f0daef3f05e